### PR TITLE
Clarify comment in def_collate_fn regarding batch size assumption

### DIFF
--- a/Util.py
+++ b/Util.py
@@ -613,7 +613,7 @@ def def_collate_fn(batch_size):
         Returns:
             A list of smaller dictionaries (batches).
         """
-        # Assume batch contains one dictionary at a time (since batch_size=1)
+        # Assume batch contains one dictionary at a time (since batch_size=1 in DataLoader)
         large_dict = batch[0]  # Extract the single dictionary from the batch
         smaller_batches = []
 


### PR DESCRIPTION
for testing pull request
This pull request includes a small change to the `Util.py` file. The change clarifies a comment in the `custom_collate_fn` function by specifying that the `batch_size=1` is in the context of the `DataLoader`.

* [`Util.py`](diffhunk://#diff-b887f64997c5dade20afe1bf1b33f4de9123995c9bf70ae38e06a1c03ba47cb8L616-R616): Clarified comment in `custom_collate_fn` function to specify `batch_size=1` is in `DataLoader`.