### PR TITLE
Fix batch size calculation in evaluate_on_dataset and train_one_epoch

### DIFF
--- a/Util.py
+++ b/Util.py
@@ -492,7 +492,7 @@ def evaluate_on_dataset(model, stage, data_loader, PARAMETERS):
     model.eval()
 
     batch_idx = 0
-    test_size = sum(len(batch) for batch in data_loader)
+    test_size = sum(len(dict_list) if not isinstance(dict_list, dict) else 1 for dict_list in data_loader)
     for dict_list_idx, dict_list in enumerate(data_loader):
         if isinstance(dict_list, dict):
             dict_list = [dict_list]

--- a/train_amp.py
+++ b/train_amp.py
@@ -43,7 +43,7 @@ def train_one_epoch(epoch, model, optimizer, loss_fn, training_loader, PARAMETER
     model.train()
 
     batch_idx = 0
-    training_size = sum(len(batch) for batch in training_loader)
+    training_size = sum(len(dict_list) if not isinstance(dict_list, dict) else 1 for dict_list in training_loader)
     for dict_list_idx, dict_list in enumerate(training_loader):
         if isinstance(dict_list, dict):
             dict_list = [dict_list]


### PR DESCRIPTION
This pull request includes changes to improve the handling of data loaders in the `Util.py` and `train_amp.py` files. The most significant changes involve modifying the calculation of `test_size` and `training_size` to better handle cases where the data loader contains dictionaries.

Improvements to data loader handling:

* [`Util.py`](diffhunk://#diff-b887f64997c5dade20afe1bf1b33f4de9123995c9bf70ae38e06a1c03ba47cb8L495-R495): Modified the calculation of `test_size` in the `evaluate_on_dataset` function to handle cases where the data loader contains dictionaries.
* [`train_amp.py`](diffhunk://#diff-0b61259fa9e340f87b1ccd545dae1340f139785bcdb3984b50bae9d851f72716L46-R46): Modified the calculation of `training_size` in the `train_one_epoch` function to handle cases where the training loader contains dictionaries.