### PR TITLE
Fix path for loading element masses in AMPQMMM class

### DIFF
--- a/AMPQMMM.py
+++ b/AMPQMMM.py
@@ -17,7 +17,7 @@ class AMPQMMM(nn.Module):
             self.mol_charge = 0.0
         self.__dict__.update(kwargs)
         self.a, self.b, self.c = 6.0, 15.0, 10.0
-        self.register_buffer("element_masses", torch.load(os.path.join("constants", "element_masses.pt")))
+        self.register_buffer("element_masses", torch.load(os.path.join(os.path.dirname(__file__), "constants", "element_masses.pt")))
         
         self.embedding_nodes = tl.Linear(self.node_size, bias=False)
         self.embedding_edges = tl.Linear(self.node_size // 4, bias=False)


### PR DESCRIPTION
This pull request includes a change to the `AMPQMMM.py` file to improve the robustness of loading the `element_masses` file. The change ensures that the file path is constructed relative to the current file's directory, which enhances portability and reduces the risk of file path issues.

* [`AMPQMMM.py`](diffhunk://#diff-93dd0151b1dbf252caf5f4af23e151f6fe46ab7a8655d32ef015902636cb89b8L20-R20): Updated the file path for loading `element_masses` to be relative to the current file's directory using `os.path.dirname(__file__)`.